### PR TITLE
id_rsa作成時に使用する環境変数名が適切ではないため修正

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-if [[ -n $EC2_SSH_KEY ]]; then
-    echo -e $EC2_SSH_KEY > ~/.ssh/ec2.pem
+if [[ -n $KITCHEN_EC2_SSH_KEY ]]; then
+    echo -e $KITCHEN_EC2_SSH_KEY > ~/.ssh/ec2.pem
     chmod 400 ~/.ssh/ec2.pem
 fi
 
-if [[ -n $GITHUB_SSH_KEY ]]; then
-    echo -e $GITHUB_SSH_KEY > ~/.ssh/id_rsa
+if [[ -n $SSH_PRIVATE_KEY ]]; then
+    echo -e $SSH_PRIVATE_KEY > ~/.ssh/id_rsa
     chmod 400 ~/.ssh/id_rsa
     ssh-keyscan github.com > ~/.ssh/known_hosts
     cat <<EOF > ~/.ssh/config


### PR DESCRIPTION
手元でcrowdworks-appを起動しているときは，コンテナ内のid_rsaはgithubへの接続（それもBerkshelf内から）に使用していた．
そのため，鍵の名前を `GITHUB_SSH_KEY` にしていた．
そしてkitchen等でEC2に接続するときには，`EC2_SSH_KEY` という別の鍵を使用していた．

しかし，yunoで動かす際には，そもそもid_rsaはEC2インスタンスへのsshで用いられている鍵であった．githubへの接続はBerkshelfが動かないので，接続する必要がない．リポジトリの取得はpersonal access tokenで行うため，本当に必要なかった．

というわけで，実行環境によって鍵の用途が若干異なる．それに合わせて名前を書き換えてみた．
